### PR TITLE
Sanitize callbacks, Refactor get_options

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.tukutoi.com/
 Tags: maintenance, under development, coming soon
 Requires at least: 4.9
 Tested up to: 5.7
-Stable tag: 2.0.0
+Stable tag: 2.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -69,6 +69,13 @@ You can take a look at the Plugin's Template in `tkt-maintenance/public/partials
 5. Plugin Settings on Install
 
 == Changelog ==
+
+= 2.0.2 =
+
+* [Security] Updated Sanitize callbacks for register settings
+* [Changed]  Refactored get_options method of plugin
+* [Removed]  Removed set_options method as not used (non-breaking change even if removed, since access was private).
+
 
 = 2.0.0 =
 

--- a/admin/class-tkt-maintenance-admin.php
+++ b/admin/class-tkt-maintenance-admin.php
@@ -205,24 +205,6 @@ class Tkt_Maintenance_Admin {
 
 	    register_setting( 
 	    	$this->section, 
-	    	$this->plugin_short . '_js', 
-	    	array( 
-	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html' 
-	    	)
-	    );
-
-	    register_setting( 
-	    	$this->section, 
-	    	$this->plugin_short . '_css', 
-	    	array( 
-	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html'  
-	    	)
-	    );
-
-	    register_setting( 
-	    	$this->section, 
 	    	$this->plugin_short . '_logo', 
 	    	array( 
 	    		'type' => 'string', 
@@ -235,7 +217,7 @@ class Tkt_Maintenance_Admin {
 	    	$this->plugin_short . '_footer',
 	    	array( 
 	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html'
+	    		'sanitize_callback' => 'sanitize_text_field'
 	    	) 
 	    );
 
@@ -244,7 +226,7 @@ class Tkt_Maintenance_Admin {
 	    	$this->plugin_short . '_header',
 	    	array( 
 	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html' 
+	    		'sanitize_callback' => 'sanitize_text_field' 
 	    	) 
 	    );
 
@@ -253,7 +235,7 @@ class Tkt_Maintenance_Admin {
 	    	$this->plugin_short . '_http_header',
 	    	array( 
 	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html' 
+	    		'sanitize_callback' => 'sanitize_text_field' 
 	    	) 
 	    );
 
@@ -286,7 +268,7 @@ class Tkt_Maintenance_Admin {
 	    	$this->plugin_short . '_time',
 	    	array( 
 	    		'type' => 'string', 
-	    		'sanitize_callback' => 'esc_html'
+	    		'sanitize_callback' => 'sanitize_text_field'
 	    	)
 	    );
 
@@ -309,7 +291,7 @@ class Tkt_Maintenance_Admin {
 	public function setting_section_cb() {
 
 		echo '<p>'. esc_html__( 'Configure and activate maintenance mode.', 'tkt-maintenance' ) .'</p>';
-		echo '<p><em>'. esc_html__( 'To add Custom CSS, use the ', 'tkt-maintenance') . '<a href="'. get_admin_url( null, 'customize.php' ) .'" target="_blank">' . esc_html__( 'Appearance Customize Screen', 'tkt-maintenance' ) . '</a>' . __( '. To add Custom JS, use ', 'tkt-maintenance' ) .'<a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/" target="_blank">'. esc_html__( ' WordPress Enqueue Functions', 'tkt-maintenance' ) .'</a>.<em></p>';
+		echo '<p><em>'. esc_html__( 'To add Custom CSS, use the ', 'tkt-maintenance') . '<a href="'. get_admin_url( null, 'customize.php' ) .'" target="_blank">' . esc_html__( 'Appearance Customize Screen', 'tkt-maintenance' ) . '</a>' . esc_html__( '. To add Custom JS, use ', 'tkt-maintenance' ) .'<a href="https://developer.wordpress.org/reference/functions/wp_enqueue_script/" target="_blank">'. esc_html__( ' WordPress Enqueue Functions', 'tkt-maintenance' ) .'</a>.<em></p>';
 
 	}
 
@@ -320,7 +302,7 @@ class Tkt_Maintenance_Admin {
 	 */
 	public function active_cb() {
 
-	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Check to activate maintenance mode', 'tkt-maintenance' ) .'</span></legend><label for="'. esc_attr( $this->plugin_short ) . '_active"><input name="'. esc_attr( $this->plugin_short ) . '_active" id="'. esc_attr( $this->plugin_short ) . '_active" type="checkbox" value="1" ' . checked( 1, get_option( $this->plugin_short . '_active' ), false ) . ' />'. esc_html__( 'Check to activate maintenance mode', 'tkt-maintenance' ) .'</label></fieldset>';
+	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Check to activate maintenance mode', 'tkt-maintenance' ) .'</span></legend><label for="'. esc_attr( $this->plugin_short ) . '_active"><input name="'. esc_attr( $this->plugin_short ) . '_active" id="'. esc_attr( $this->plugin_short ) . '_active" type="checkbox" value="1" ' . checked( 1, $this->validate_number( get_option( $this->plugin_short . '_active' ) ), false ) . ' />'. esc_html__( 'Check to activate maintenance mode', 'tkt-maintenance' ) .'</label></fieldset>';
 
 	} 
 
@@ -331,7 +313,7 @@ class Tkt_Maintenance_Admin {
 	 */
 	public function dequeue_styles_scripts() {
 
-	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Check to dequeue all styles and scripts during maintenance mode', 'tkt-maintenance' ) .'</span></legend><label for="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts"><input name="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts" id="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts" type="checkbox" value="1" ' . checked( 1, get_option( $this->plugin_short . '_dequeue_styles_scripts' ), false ) . ' />'. esc_html__( 'Check to dequeue all styles and scripts during maintenance mode', 'tkt-maintenance' ) .'</label></fieldset>';
+	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Check to dequeue all styles and scripts during maintenance mode', 'tkt-maintenance' ) .'</span></legend><label for="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts"><input name="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts" id="'. esc_attr( $this->plugin_short ) . '_dequeue_styles_scripts" type="checkbox" value="1" ' . checked( 1, $this->validate_number( get_option( $this->plugin_short . '_dequeue_styles_scripts' ) ), false ) . ' />'. esc_html__( 'Check to dequeue all styles and scripts during maintenance mode', 'tkt-maintenance' ) .'</label></fieldset>';
 
 	}  
 
@@ -408,7 +390,7 @@ class Tkt_Maintenance_Admin {
 	 */
 	public function time_cb() {
 
-	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Add your own Countdown End Time', 'tkt-maintenance' ) .'</span></legend><input name="'. esc_attr( $this->plugin_short ) . '_time" id="'. esc_attr( $this->plugin_short ) . '_time" type="text" value="' . sanitize_text_field ( get_option( $this->plugin_short . '_time' ) ) . '" /><p class="description">'. esc_html__( 'Add your own Countdown End Time. Any valid JS ', 'tkt-maintenance' ) . '<a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#examples"><code>Date()</code></a>'. esc_html__( 'format accepted.', 'tkt-maintenance' ) .'</p></fieldset>';
+	  	echo '<fieldset><legend class="screen-reader-text"><span>'. esc_html__( 'Add your own Countdown End Time', 'tkt-maintenance' ) .'</span></legend><input name="'. esc_attr( $this->plugin_short ) . '_time" id="'. esc_attr( $this->plugin_short ) . '_time" type="text" value="' . sanitize_text_field( get_option( $this->plugin_short . '_time' ) ) . '" /><p class="description">'. esc_html__( 'Add your own Countdown End Time. Any valid JS ', 'tkt-maintenance' ) . '<a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#examples"><code>Date()</code></a>'. esc_html__( 'format accepted.', 'tkt-maintenance' ) .'</p></fieldset>';
 
 	}  
 

--- a/public/class-tkt-maintenance-options.php
+++ b/public/class-tkt-maintenance-options.php
@@ -53,7 +53,13 @@ class Tkt_Options {
 
 	}
 
-	private function set_options(){
+	/**
+	 * Get and Escape Option Values.
+	 *
+	 * @since 	1.0.0
+	 * @return 	array 	$options  	The Options of this plugin, escaped, ready to echo.
+	 */
+	public function get_options(){
 
 		$options = array(
 			$this->plugin_short . '_active'	=> (int) get_option( $this->plugin_short . '_active', 0 ),
@@ -69,12 +75,6 @@ class Tkt_Options {
 		);
 
 		return $options;
-
-    }
-
-    public function get_options(){
-
-    	return $this->set_options();
 
     }
 

--- a/tkt-maintenance.php
+++ b/tkt-maintenance.php
@@ -16,7 +16,7 @@
  * Plugin Name:       TukuToi Maintenance
  * Plugin URI:        https://www.tukutoi.com/program/tukutoi-maintenance
  * Description:       Enable and Control a Custom Maintenance Mode for your WordPress Website.
- * Version:           2.0.0
+ * Version:           2.0.2
  * Author:            TukuToi
  * Author URI:        https://www.tukutoi.com/
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define( 'TKT_MAINTENANCE_VERSION', '2.0.0' );
+define( 'TKT_MAINTENANCE_VERSION', '2.0.2' );
 
 /**
  * The core plugin class that is used to define internationalization,


### PR DESCRIPTION
- We should _sanitize_ when save and _escape_ when output. Corrected the callbacks for register settings to reflect that
- Refactored get_options method because it was confusing
- updated version.